### PR TITLE
35 group

### DIFF
--- a/pipeline_kafka--0.9.3.sql
+++ b/pipeline_kafka--0.9.3.sql
@@ -6,6 +6,7 @@ CREATE TABLE pipeline_kafka.consumers (
   id          serial  PRIMARY KEY,
   topic       text    NOT NULL,
   relation    text    NOT NULL,
+  group_id		text,
   format      text    NOT NULL,
   delimiter   text,
   quote       text,
@@ -34,6 +35,7 @@ CREATE TABLE pipeline_kafka.brokers (
 CREATE FUNCTION pipeline_kafka.consume_begin (
   topic        text,
   relation     text,
+  group_id     text    DEFAULT NULL,
   format       text    DEFAULT 'text',
   delimiter    text    DEFAULT E'\t',
   quote        text    DEFAULT NULL,
@@ -97,6 +99,7 @@ LANGUAGE C IMMUTABLE;
 
 CREATE FUNCTION pipeline_kafka.consume_begin_stream_partitioned (
   topic        text,
+  group_id     text    DEFAULT NULL,
   format       text    DEFAULT 'text',
   delimiter    text    DEFAULT E'\t',
   quote        text    DEFAULT NULL,

--- a/pipeline_kafka.c
+++ b/pipeline_kafka.c
@@ -703,10 +703,17 @@ save_consumer_offsets(KafkaConsumer *consumer, int partition_group)
 	{
 		for (partition = 0; partition < consumer->num_partitions; partition++)
 		{
+			rd_kafka_resp_err_t err;
+
 			if (partition % consumer->parallelism != partition_group)
 				continue;
-			// error check
-			rd_kafka_offset_store(consumer->topic, partition, consumer->offsets[partition]);
+
+			err = rd_kafka_offset_store(consumer->topic, partition, consumer->offsets[partition]);
+			if (err)
+			{
+				elog(LOG, CONSUMER_LOG_PREFIX "librdkafka error: %s",
+						CONSUMER_LOG_PREFIX_PARAMS(consumer), rd_kafka_err2str(err));
+			}
 		}
 		return;
 	}

--- a/pipeline_kafka.c
+++ b/pipeline_kafka.c
@@ -61,18 +61,19 @@ PG_MODULE_MAGIC;
 #define PIPELINE_KAFKA_SCHEMA "pipeline_kafka"
 
 #define CONSUMER_RELATION "consumers"
-#define CONSUMER_RELATION_NATTS		11
+#define CONSUMER_RELATION_NATTS		12
 #define CONSUMER_ATTR_ID	 		1
 #define CONSUMER_ATTR_TOPIC			2
 #define CONSUMER_ATTR_RELATION 		3
-#define CONSUMER_ATTR_FORMAT 		4
-#define CONSUMER_ATTR_DELIMITER 	5
-#define CONSUMER_ATTR_QUOTE			6
-#define CONSUMER_ATTR_ESCAPE		7
-#define CONSUMER_ATTR_BATCH_SIZE 	8
-#define CONSUMER_ATTR_MAX_BYTES 	9
-#define CONSUMER_ATTR_PARALLELISM 	10
-#define CONSUMER_ATTR_TIMEOUT	 	11
+#define CONSUMER_ATTR_GROUP_ID	4
+#define CONSUMER_ATTR_FORMAT 		5
+#define CONSUMER_ATTR_DELIMITER 	6
+#define CONSUMER_ATTR_QUOTE			7
+#define CONSUMER_ATTR_ESCAPE		8
+#define CONSUMER_ATTR_BATCH_SIZE 	9
+#define CONSUMER_ATTR_MAX_BYTES 	10
+#define CONSUMER_ATTR_PARALLELISM 	11
+#define CONSUMER_ATTR_TIMEOUT	 	12
 
 #define OFFSETS_RELATION "offsets"
 #define OFFSETS_RELATION_NATTS	3
@@ -112,7 +113,7 @@ PG_MODULE_MAGIC;
 static volatile sig_atomic_t got_SIGTERM = false;
 static rd_kafka_t *MyKafka = NULL;
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
-static char *broker_version;
+static char *broker_version = NULL;
 
 void _PG_init(void);
 
@@ -229,12 +230,16 @@ typedef struct KafkaConsumer
 	int max_bytes;
 	int parallelism;
 	int timeout;
+	char *group_id;
 	char *format;
 	char *delimiter;
 	char *quote;
 	char *escape;
 	int num_partitions;
 	int64_t *offsets;
+	rd_kafka_t *kafka;
+	rd_kafka_topic_partition_list_t *partitions;
+	rd_kafka_topic_t *rd_topic;
 } KafkaConsumer;
 
 /* Shared-memory hashtable for storing consumer process group information */
@@ -455,24 +460,31 @@ load_consumer_offsets(KafkaConsumer *consumer, struct rd_kafka_metadata_topic *m
 	ScanKeyData skey[1];
 	HeapTuple tup = NULL;
 	IndexScanDesc scan;
-	ResultRelInfo *offsets = relinfo_open(get_rangevar(OFFSETS_RELATION), RowExclusiveLock);
-	TupleTableSlot *slot = MakeSingleTupleTableSlot(RelationGetDescr(offsets->ri_RelationDesc));
+	ResultRelInfo *offsets;
+	TupleTableSlot *slot;
 	int i;
+
+	old = MemoryContextSwitchTo(CacheMemoryContext);
+	consumer->offsets = palloc0(meta->partition_cnt * sizeof(int64_t));
+	MemoryContextSwitchTo(old);
+
+	/*
+	 * Consumers with a group get their offsets from brokers
+	 */
+	if (consumer->group_id)
+		return;
+
+	offsets = relinfo_open(get_rangevar(OFFSETS_RELATION), RowExclusiveLock);
+	slot = MakeSingleTupleTableSlot(RelationGetDescr(offsets->ri_RelationDesc));
 
 	ScanKeyInit(&skey[0], 1, BTEqualStrategyNumber, F_OIDEQ, ObjectIdGetDatum(consumer->id));
 	scan = index_beginscan(offsets->ri_RelationDesc, offsets->ri_IndexRelationDescs[1],
 			GetTransactionSnapshot(), 1, 0);
 	index_rescan(scan, skey, 1, NULL, 0);
 
-	old = MemoryContextSwitchTo(CacheMemoryContext);
-	consumer->offsets = palloc0(meta->partition_cnt * sizeof(int64_t));
-	MemoryContextSwitchTo(old);
-
 	/* by default, begin consuming from the end of a stream */
 	for (i = 0; i < meta->partition_cnt; i++)
 		consumer->offsets[i] = start_offset;
-
-	consumer->num_partitions = meta->partition_cnt;
 
 	while ((tup = index_getnext(scan, ForwardScanDirection)) != NULL)
 	{
@@ -575,6 +587,13 @@ load_consumer_state(int32 consumer_id, KafkaConsumer *consumer)
 	Assert(!isnull);
 	consumer->topic = TextDatumGetCString(d);
 
+	/* consumer group id */
+	d = slot_getattr(slot, CONSUMER_ATTR_GROUP_ID, &isnull);
+	if (!isnull)
+		consumer->group_id = TextDatumGetCString(d);
+	else
+		consumer->group_id = NULL;
+
 	/* format */
 	d = slot_getattr(slot, CONSUMER_ATTR_FORMAT, &isnull);
 	consumer->format = TextDatumGetCString(d);
@@ -626,6 +645,8 @@ load_consumer_state(int32 consumer_id, KafkaConsumer *consumer)
 	ExecDropSingleTupleTableSlot(slot);
 	index_endscan(scan);
 	relinfo_close(consumers, NoLock);
+
+	consumer->partitions = rd_kafka_topic_partition_list_new(1);
 }
 
 /*
@@ -661,13 +682,22 @@ save_consumer_offsets(KafkaConsumer *consumer, int partition_group)
 	ScanKeyData skey[1];
 	HeapTuple tup = NULL;
 	IndexScanDesc scan;
-	ResultRelInfo *offsets = relinfo_open(get_rangevar(OFFSETS_RELATION), RowExclusiveLock);
+	ResultRelInfo *offsets;
 	Datum values[OFFSETS_RELATION_NATTS];
 	bool nulls[OFFSETS_RELATION_NATTS];
 	bool replace[OFFSETS_RELATION_NATTS];
 	bool updated[consumer->num_partitions];
-	TupleTableSlot *slot = MakeSingleTupleTableSlot(RelationGetDescr(offsets->ri_RelationDesc));
+	TupleTableSlot *slot;
 	int partition;
+
+	/*
+	 * Consumers with a group store offsets in brokers
+	 */
+	if (consumer->group_id)
+		return;
+
+	offsets = relinfo_open(get_rangevar(OFFSETS_RELATION), RowExclusiveLock);
+	slot = MakeSingleTupleTableSlot(RelationGetDescr(offsets->ri_RelationDesc));
 
 	MemSet(updated, false, sizeof(updated));
 
@@ -843,6 +873,10 @@ execute_copy(KafkaConsumer *consumer, KafkaConsumerProc *proc, CopyStmt *stmt, S
 	if (!IsTransactionState())
 		StartTransactionCommand();
 
+	/*
+	 * We only store offsets if we're not part of a consumer group.
+	 * Consumer groups store their offsets in Kafka.
+	 */
 	save_consumer_offsets(consumer, proc->partition_group);
 
 	CommitTransactionCommand();
@@ -861,6 +895,7 @@ consume_topic_into_relation(KafkaConsumer *consumer, KafkaConsumerProc *proc, rd
 	copy = get_copy_statement(consumer);
 	CommitTransactionCommand();
 
+	consumer->rd_topic = topic;
 	messages = MemoryContextAlloc(CacheMemoryContext, sizeof(rd_kafka_message_t *) * consumer->batch_size);
 
 	/*
@@ -1126,7 +1161,6 @@ kafka_consume_main(Datum arg)
 	char err_msg[512];
 	rd_kafka_topic_conf_t *topic_conf;
 	rd_kafka_conf_t *conf;
-	rd_kafka_t *kafka = NULL;
 	rd_kafka_topic_t *topic = NULL;
 	const struct rd_kafka_metadata *meta;
 	struct rd_kafka_metadata_topic topic_meta;
@@ -1176,8 +1210,15 @@ kafka_consume_main(Datum arg)
 	if (broker_version)
 		rd_kafka_conf_set(conf, "broker.version.fallback", broker_version, NULL, 0);
 
-	kafka = rd_kafka_new(RD_KAFKA_CONSUMER, conf, err_msg, sizeof(err_msg));
-	rd_kafka_set_logger(kafka, consumer_logger);
+	if (consumer.group_id)
+	{
+		rd_kafka_conf_set(conf, "group.id", consumer.group_id, NULL, 0);
+		rd_kafka_conf_set(conf, "offset.store.method", "broker", NULL, 0);
+		rd_kafka_topic_conf_set(topic_conf, "topic.auto.offset.reset", "smallest", NULL, 0);
+	}
+
+	consumer.kafka = rd_kafka_new(RD_KAFKA_CONSUMER, conf, err_msg, sizeof(err_msg));
+	rd_kafka_set_logger(consumer.kafka, consumer_logger);
 
 	/*
 	 * Add all brokers currently in pipeline_kafka.brokers
@@ -1190,7 +1231,7 @@ kafka_consume_main(Datum arg)
 	}
 
 	foreach(lc, consumer.brokers)
-		valid_brokers += rd_kafka_brokers_add(kafka, lfirst(lc));
+		valid_brokers += rd_kafka_brokers_add(consumer.kafka, lfirst(lc));
 
 	if (!valid_brokers)
 		elog(ERROR, CONSUMER_LOG_PREFIX "no valid brokers were found",
@@ -1199,8 +1240,8 @@ kafka_consume_main(Datum arg)
 	/*
 	 * Set up our topic to read from
 	 */
-	topic = rd_kafka_topic_new(kafka, consumer.topic, topic_conf);
-	err = rd_kafka_metadata(kafka, false, topic, &meta, KAFKA_META_TIMEOUT);
+	topic = rd_kafka_topic_new(consumer.kafka, consumer.topic, topic_conf);
+	err = rd_kafka_metadata(consumer.kafka, false, topic, &meta, KAFKA_META_TIMEOUT);
 
 	if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
 		elog(ERROR, CONSUMER_LOG_PREFIX "failed to acquire metadata: %s",
@@ -1208,6 +1249,8 @@ kafka_consume_main(Datum arg)
 
 	Assert(meta->topic_cnt == 1);
 	topic_meta = meta->topics[0];
+	consumer.num_partitions = topic_meta.partition_cnt;
+
 	load_consumer_offsets(&consumer, &topic_meta, proc->start_offset);
 	CommitTransactionCommand();
 
@@ -1217,15 +1260,18 @@ kafka_consume_main(Datum arg)
 	for (i = 0; i < topic_meta.partition_cnt; i++)
 	{
 		int partition = topic_meta.partitions[i].id;
+		int64_t start_offset;
 
 		Assert(partition <= consumer.num_partitions);
 		if (partition % consumer.parallelism != proc->partition_group)
 			continue;
 
-		elog(LOG, CONSUMER_LOG_PREFIX "consuming partition %d from offset %ld",
-				CONSUMER_LOG_PREFIX_PARAMS(&consumer), partition, consumer.offsets[partition]);
+		start_offset = consumer.group_id ? RD_KAFKA_OFFSET_STORED : consumer.offsets[partition];
 
-		if (rd_kafka_consume_start(topic, partition, consumer.offsets[partition]) == -1)
+		elog(LOG, CONSUMER_LOG_PREFIX "consuming partition %d from offset %ld",
+				CONSUMER_LOG_PREFIX_PARAMS(&consumer), partition, start_offset);
+
+		if (rd_kafka_consume_start(topic, partition, start_offset) == -1)
 			elog(ERROR, CONSUMER_LOG_PREFIX "failed to start consuming: %s",
 					CONSUMER_LOG_PREFIX_PARAMS(&consumer), rd_kafka_err2str(rd_kafka_errno2err(errno)));
 
@@ -1259,11 +1305,25 @@ kafka_consume_main(Datum arg)
 done:
 	hash_search(consumer_procs, &id, HASH_REMOVE, NULL);
 
-	if (kafka)
+	for (i = 0; i < topic_meta.partition_cnt; i++)
+	{
+		int partition = topic_meta.partitions[i].id;
+
+		Assert(partition <= consumer.num_partitions);
+		if (partition % consumer.parallelism != proc->partition_group)
+			continue;
+
+		rd_kafka_consume_stop(topic, partition);
+		elog(LOG, CONSUMER_LOG_PREFIX "stopped consuming partition %d", CONSUMER_LOG_PREFIX_PARAMS(&consumer), partition);
+	}
+
+	if (consumer.kafka)
 	{
 		if (topic)
 			rd_kafka_topic_destroy(topic);
-		rd_kafka_destroy(kafka);
+
+		rd_kafka_consumer_close(consumer.kafka);
+		rd_kafka_destroy(consumer.kafka);
 		rd_kafka_wait_destroyed(KAFKA_META_TIMEOUT);
 	}
 }
@@ -1275,7 +1335,7 @@ done:
  */
 static int32
 create_or_update_consumer(ResultRelInfo *consumers, text *relation, text *topic,
-		text *format, text *delimiter, text *quote, text *escape, int batchsize, int maxbytes,
+		text *group_id, text *format, text *delimiter, text *quote, text *escape, int batchsize, int maxbytes,
 		int parallelism, int timeout)
 {
 	HeapTuple tup;
@@ -1304,6 +1364,11 @@ create_or_update_consumer(ResultRelInfo *consumers, text *relation, text *topic,
 	values[CONSUMER_ATTR_PARALLELISM - 1] = Int32GetDatum(parallelism);
 	values[CONSUMER_ATTR_TIMEOUT - 1] = Int32GetDatum(timeout);
 	values[CONSUMER_ATTR_FORMAT - 1] = PointerGetDatum(format);
+
+	if (group_id == NULL)
+		nulls[CONSUMER_ATTR_GROUP_ID - 1] = true;
+	else
+		values[CONSUMER_ATTR_GROUP_ID - 1] = PointerGetDatum(group_id);
 
 	if (delimiter == NULL)
 		nulls[CONSUMER_ATTR_DELIMITER - 1] = true;
@@ -1503,6 +1568,7 @@ kafka_consume_begin(PG_FUNCTION_ARGS)
 	ResultRelInfo *consumers;
 	Oid id;
 	bool success;
+	text *group_id;
 	text *format;
 	text *delimiter;
 	text *quote;
@@ -1520,7 +1586,7 @@ kafka_consume_begin(PG_FUNCTION_ARGS)
 		elog(ERROR, "topic cannot be null");
 	if (PG_ARGISNULL(1))
 		elog(ERROR, "relation cannot be null");
-	if (PG_ARGISNULL(2))
+	if (PG_ARGISNULL(3))
 		elog(ERROR, "format cannot be null");
 
 	/* there's no point in progressing if there aren't any brokers */
@@ -1529,17 +1595,23 @@ kafka_consume_begin(PG_FUNCTION_ARGS)
 
 	topic = PG_GETARG_TEXT_P(0);
 	qualified_name = PG_GETARG_TEXT_P(1);
-	format = PG_GETARG_TEXT_P(2);
 
-	if (PG_ARGISNULL(3))
-		delimiter = NULL;
+	if (PG_ARGISNULL(2))
+		group_id = NULL;
 	else
-		delimiter = PG_GETARG_TEXT_P(3);
+		group_id = PG_GETARG_TEXT_P(2);
+
+	format = PG_GETARG_TEXT_P(3);
 
 	if (PG_ARGISNULL(4))
+		delimiter = NULL;
+	else
+		delimiter = PG_GETARG_TEXT_P(4);
+
+	if (PG_ARGISNULL(5))
 		quote = NULL;
 	else
-		quote = PG_GETARG_TEXT_P(4);
+		quote = PG_GETARG_TEXT_P(5);
 
 	if (pg_strcasecmp(TextDatumGetCString(format), FORMAT_JSON) == 0)
 	{
@@ -1549,35 +1621,35 @@ kafka_consume_begin(PG_FUNCTION_ARGS)
 		quote = (text *) CStringGetTextDatum(FORMAT_JSON_QUOTE);
 	}
 
-	if (PG_ARGISNULL(5))
+	if (PG_ARGISNULL(6))
 		escape = NULL;
 	else
-		escape = PG_GETARG_TEXT_P(5);
-
-	if (PG_ARGISNULL(6))
-		batchsize = 10000;
-	else
-		batchsize = PG_GETARG_INT32(6);
+		escape = PG_GETARG_TEXT_P(6);
 
 	if (PG_ARGISNULL(7))
-		maxbytes = 32000000;
+		batchsize = 10000;
 	else
-		maxbytes = PG_GETARG_INT32(7);
+		batchsize = PG_GETARG_INT32(7);
 
 	if (PG_ARGISNULL(8))
-		parallelism = 1;
+		maxbytes = 32000000;
 	else
-		parallelism = PG_GETARG_INT32(8);
+		maxbytes = PG_GETARG_INT32(8);
 
 	if (PG_ARGISNULL(9))
-		timeout = 250;
+		parallelism = 1;
 	else
-		timeout = PG_GETARG_INT32(9);
+		parallelism = PG_GETARG_INT32(9);
 
 	if (PG_ARGISNULL(10))
+		timeout = 250;
+	else
+		timeout = PG_GETARG_INT32(10);
+
+	if (PG_ARGISNULL(11))
 		offset = RD_KAFKA_OFFSET_NULL;
 	else
-		offset = PG_GETARG_INT64(10);
+		offset = PG_GETARG_INT64(11);
 
 	/* verify that the target relation actually exists */
 	relname = makeRangeVarFromNameList(textToQualifiedNameList(qualified_name));
@@ -1585,7 +1657,7 @@ kafka_consume_begin(PG_FUNCTION_ARGS)
 	heap_close(rel, NoLock);
 
 	consumers = relinfo_open(get_rangevar(CONSUMER_RELATION), ExclusiveLock);
-	id = create_or_update_consumer(consumers, qualified_name, topic, format,
+	id = create_or_update_consumer(consumers, qualified_name, topic, group_id, format,
 			delimiter, quote, escape, batchsize, maxbytes, parallelism, timeout);
 	load_consumer_state(id, &consumer);
 	success = launch_consumer_group(&consumer, offset);
@@ -2014,6 +2086,7 @@ kafka_consume_begin_stream_partitioned(PG_FUNCTION_ARGS)
 	ResultRelInfo *consumers;
 	Oid id;
 	bool success;
+	text *group_id;
 	text *format;
 	text *delimiter;
 	text *quote;
@@ -2029,7 +2102,7 @@ kafka_consume_begin_stream_partitioned(PG_FUNCTION_ARGS)
 
 	if (PG_ARGISNULL(0))
 		elog(ERROR, "topic cannot be null");
-	if (PG_ARGISNULL(1))
+	if (PG_ARGISNULL(2))
 		elog(ERROR, "format cannot be null");
 
 	/* there's no point in progressing if there aren't any brokers */
@@ -2037,17 +2110,23 @@ kafka_consume_begin_stream_partitioned(PG_FUNCTION_ARGS)
 		elog(ERROR, "add at least one broker with pipeline_kafka.add_broker");
 
 	topic = PG_GETARG_TEXT_P(0);
-	format = PG_GETARG_TEXT_P(1);
 
-	if (PG_ARGISNULL(2))
-		delimiter = NULL;
+	if (PG_ARGISNULL(1))
+		group_id = NULL;
 	else
-		delimiter = PG_GETARG_TEXT_P(2);
+		group_id = PG_GETARG_TEXT_P(1);
+
+	format = PG_GETARG_TEXT_P(2);
 
 	if (PG_ARGISNULL(3))
+		delimiter = NULL;
+	else
+		delimiter = PG_GETARG_TEXT_P(3);
+
+	if (PG_ARGISNULL(4))
 		quote = NULL;
 	else
-		quote = PG_GETARG_TEXT_P(3);
+		quote = PG_GETARG_TEXT_P(4);
 
 	if (pg_strcasecmp(TextDatumGetCString(format), FORMAT_JSON) == 0)
 	{
@@ -2057,38 +2136,38 @@ kafka_consume_begin_stream_partitioned(PG_FUNCTION_ARGS)
 		quote = (text *) CStringGetTextDatum(FORMAT_JSON_QUOTE);
 	}
 
-	if (PG_ARGISNULL(4))
+	if (PG_ARGISNULL(5))
 		escape = NULL;
 	else
-		escape = PG_GETARG_TEXT_P(4);
-
-	if (PG_ARGISNULL(5))
-		batchsize = 10000;
-	else
-		batchsize = PG_GETARG_INT32(5);
+		escape = PG_GETARG_TEXT_P(5);
 
 	if (PG_ARGISNULL(6))
-		maxbytes = 32000000;
+		batchsize = 10000;
 	else
-		maxbytes = PG_GETARG_INT32(6);
+		batchsize = PG_GETARG_INT32(6);
 
 	if (PG_ARGISNULL(7))
-		parallelism = 1;
+		maxbytes = 32000000;
 	else
-		parallelism = PG_GETARG_INT32(7);
+		maxbytes = PG_GETARG_INT32(7);
 
 	if (PG_ARGISNULL(8))
-		timeout = 250;
+		parallelism = 1;
 	else
-		timeout = PG_GETARG_INT32(8);
+		parallelism = PG_GETARG_INT32(8);
 
 	if (PG_ARGISNULL(9))
+		timeout = 250;
+	else
+		timeout = PG_GETARG_INT32(9);
+
+	if (PG_ARGISNULL(10))
 		offset = RD_KAFKA_OFFSET_NULL;
 	else
-		offset = PG_GETARG_INT64(9);
+		offset = PG_GETARG_INT64(10);
 
 	consumers = relinfo_open(get_rangevar(CONSUMER_RELATION), ExclusiveLock);
-	id = create_or_update_consumer(consumers, NULL, topic, format,
+	id = create_or_update_consumer(consumers, NULL, topic, group_id, format,
 			delimiter, quote, escape, batchsize, maxbytes, parallelism, timeout);
 	load_consumer_state(id, &consumer);
 	success = launch_consumer_group(&consumer, offset);

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ test: run-kafka
 	docker-compose stop
 	
 run-kafka:
-	docker-compose rm -f
+	docker-compose rm -f --all
 	docker-compose up -d --force-recreate
 
 clean:

--- a/test/base.py
+++ b/test/base.py
@@ -312,7 +312,8 @@ class PipelineDB(object):
 
   def consume_begin(self, topic, stream, format='text', delimiter='\t',
                     quote=None, escape=None, batchsize=1000,
-                    maxbytes=32000000, parallelism=1, start_offset=None):
+                    maxbytes=32000000, parallelism=1, start_offset=None,
+                    group_id=None):
     """
     Begin consuming with the given parameters
     """
@@ -325,6 +326,7 @@ class PipelineDB(object):
       'maxbytes': maxbytes,
       'parallelism': parallelism,
       'start_offset': start_offset,
+      'group_id': group_id
     }
     args = [repr(topic), repr(stream)]
     args.extend(['%s := %s' % (k, v and repr(v).replace("'\\", "E'\\") or 'NULL') for k, v in params.items()])
@@ -344,7 +346,8 @@ class PipelineDB(object):
 
   def consume_begin_stream_partitioned(self, topic, format='text', delimiter='\t',
                     quote=None, escape=None, batchsize=1000,
-                    maxbytes=32000000, parallelism=1, start_offset=None):
+                    maxbytes=32000000, parallelism=1, start_offset=None,
+                    group_id=None):
     """
     Begin consuming a stream-partitioned topic with the given parameters
     """
@@ -356,7 +359,8 @@ class PipelineDB(object):
       'batchsize': batchsize,
       'maxbytes': maxbytes,
       'parallelism': parallelism,
-      'start_offset': start_offset
+      'start_offset': start_offset,
+      'group_id': group_id
     }
     args = [repr(topic)]
     args.extend(['%s := %s' % (k, v and repr(v).replace("'\\", "E'\\") or 'NULL') for k, v in params.items()])

--- a/test/test_pipeline_kafka.py
+++ b/test/test_pipeline_kafka.py
@@ -223,8 +223,80 @@ def test_consume_json(pipeline, kafka, clean_db):
   assert eventually(unpack_cv)
 
 
-def test_grouped_consumer():
+def test_grouped_consumer(pipeline, kafka, clean_db):
   """
   Verify that consumers with a group.id store offsets in Kafka and consume
   partitions correctly.
   """
+  pipeline.create_stream('stream0', x='integer')
+  pipeline.create_stream('stream1', x='integer')
+  pipeline.create_cv('group0', "SELECT x, COUNT(*) FROM stream0 GROUP BY x")
+  pipeline.create_cv('group1', "SELECT x, COUNT(*) FROM stream1 GROUP BY x")
+
+  kafka.create_topic('topic0', partitions=4)
+  kafka.create_topic('topic1', partitions=4)
+
+  pipeline.consume_begin('topic0', 'stream0', group_id='group0')
+  pipeline.consume_begin('topic1', 'stream1', group_id='group1')
+
+  producer0 = kafka.get_producer('topic0')
+  producer1 = kafka.get_producer('topic1')
+
+  for n in range(1, 101):
+    producer0.produce(str(n))
+    producer1.produce(str(n))
+
+  def counts():
+    rows = pipeline.execute('SELECT sum(count) FROM group0')
+    assert rows[0][0] == 100
+
+    rows = pipeline.execute('SELECT sum(count) FROM group1')
+    assert rows[0][0] == 100
+
+    rows = pipeline.execute('SELECT count(*) FROM group0')
+    assert rows[0][0] == 100
+
+    rows = pipeline.execute('SELECT count(*) FROM group1')
+    assert rows[0][0] == 100
+
+  assert eventually(counts)
+
+  pipeline.consume_end()
+
+  # Verify offsets aren't stored locally
+  rows = pipeline.execute('SELECT * FROM pipeline_kafka.offsets')
+  assert not rows
+
+  # Now produce some more
+  for n in range(1, 101):
+    producer0.produce(str(-n))
+    producer1.produce(str(-n))
+
+  pipeline.consume_begin('topic0', 'stream0', group_id='group0')
+  pipeline.consume_begin('topic1', 'stream1', group_id='group1')
+
+  # And verify that only the second batch of messages was read
+  def counts_after_restart():
+    rows = pipeline.execute('SELECT sum(x) FROM group0')
+    assert rows[0][0] == 0
+
+    rows = pipeline.execute('SELECT sum(x) FROM group1')
+    assert rows[0][0] == 0
+
+    rows = pipeline.execute('SELECT sum(count) FROM group0')
+    assert rows[0][0] == 200
+
+    rows = pipeline.execute('SELECT sum(count) FROM group1')
+    assert rows[0][0] == 200
+
+    rows = pipeline.execute('SELECT count(*) FROM group0')
+    assert rows[0][0] == 200
+
+    rows = pipeline.execute('SELECT count(*) FROM group1')
+    assert rows[0][0] == 200
+
+  assert eventually(counts_after_restart)
+
+  # Verify that offsets still aren't stored locally
+  rows = pipeline.execute('SELECT * FROM pipeline_kafka.offsets')
+  assert not rows

--- a/test/test_pipeline_kafka.py
+++ b/test/test_pipeline_kafka.py
@@ -221,3 +221,10 @@ def test_consume_json(pipeline, kafka, clean_db):
       assert k.replace('v', '') == arr_el
 
   assert eventually(unpack_cv)
+
+
+def test_grouped_consumer():
+  """
+  Verify that consumers with a group.id store offsets in Kafka and consume
+  partitions correctly.
+  """


### PR DESCRIPTION
Consumers can now be started with a `group_id`, which causes offsets to be stored in brokers.
- [x] Force offset commit in `save_consumer_offsets`
- [x] Respect `offset` parameter
